### PR TITLE
Fix #2: Move defer after error handling in url lookups

### DIFF
--- a/bitbot/links.go
+++ b/bitbot/links.go
@@ -29,10 +29,10 @@ func isURL(message string) bool {
 func lookupPageTitle(message string) string {
 	url := xurls.Strict.FindString(message)
 	resp, err := http.Get(url)
-	defer resp.Body.Close()
 	if err != nil {
 		return ""
 	}
+	defer resp.Body.Close()
 	fmt.Println("Unable to lookup page")
 	if title, ok := GetHtmlTitle(resp.Body); ok {
 		return(title)


### PR DESCRIPTION
Moving defer after the error handler ensures that `resp.Body.Close()` is only deferred if there is no error (and thus a `resp.Body` can be safely `Close()`ed)