### PR TITLE
Add compile output information to aid in debugging

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 #! /bin/sh
 
 # Get latest commit, tag, and branch we build on
-export GIT_COMMIT=$(git rev-list -1 HEAD) && export GIT_TAG=$(git describe --abbrev=0 --tags) && export GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD) && go install -ldflags "-X github.com/bbriggs/bitbot/bitbot.GitCommit=$GIT_COMMIT -X github.com/bbriggs/bitbot/bitbot.GitVersion=$GIT_TAG -X github.com/bbriggs/bitbot/bitbot.GitBranch=$GIT_BRANCH"
+export GIT_COMMIT=$(git rev-list -1 HEAD) && export GIT_TAG=$(git describe --abbrev=0 --tags) && export GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD) && go install -ldflags "-X github.com/bbriggs/bitbot/bitbot.GitCommit=$GIT_COMMIT -X github.com/bbriggs/bitbot/bitbot.GitVersion=$GIT_TAG -X github.com/bbriggs/bitbot/bitbot.GitBranch=$GIT_BRANCH" && echo "Compiled bitbot:\n\tGit tag: $GIT_TAG\n\tGit commit: $GIT_COMMIT\n\tGit branch: $GIT_BRANCH\n"


### PR DESCRIPTION
```
./build.sh
Compiled bitbot:
        Git tag: 0.1.0
        Git commit: ad1c453b17f46712043d1ffa7d8621ad0a1ade1e
        Git branch: build-time-debugging
```