### PR TITLE
Add skip flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+   - Skip processing of a message by prefixing your message with !skip
 
 ## [0.1.1] - 2018-10-08
 ### Added

--- a/bitbot/bot.go
+++ b/bitbot/bot.go
@@ -37,10 +37,15 @@ func Run(server string, nick string, channels []string, ssl bool) {
 
 	b.Bot = irc
 	b.DB = db
+
 	// Triggers to run
+	// Passive triggers. Unskippable.
+	b.Bot.AddTrigger(TrackIdleUsers)
+
+	// Begin with skip prefix (!skip)
+	b.Bot.AddTrigger(SkipTrigger)
 	b.Bot.AddTrigger(InfoTrigger)
 	b.Bot.AddTrigger(ShrugTrigger)
-	b.Bot.AddTrigger(TrackIdleUsers)
 	b.Bot.AddTrigger(ReportIdleUsers)
 	b.Bot.AddTrigger(URLReaderTrigger)
 	b.Bot.Logger.SetHandler(log.StreamHandler(os.Stdout, log.JsonFormat()))

--- a/bitbot/skip.go
+++ b/bitbot/skip.go
@@ -1,0 +1,17 @@
+package bitbot
+
+import (
+	"github.com/whyrusleeping/hellabot"
+	"strings"
+)
+
+// SkipTrigger sets a message prefix that instructs bitbot not to process the message
+// Should be set before any "skippable" triggers and after any triggers that run on all messages (unskippable)
+var SkipTrigger = hbot.Trigger{
+	func(irc *hbot.Bot, m *hbot.Message) bool {
+		return m.Command == "PRIVMSG" && strings.HasPrefix(m.Content,"!skip")
+	},
+	func(irc *hbot.Bot, m *hbot.Message) bool {
+		return true  // Do nothing and stop processing any more triggers
+	},
+}


### PR DESCRIPTION
Skip processing of a message by prefixing with `!skip`

Useful for dropping multiple links back to back.