### PR TITLE
Add support for nickserv, server oper, and channel oper

### DIFF
--- a/bitbot/bot.go
+++ b/bitbot/bot.go
@@ -14,38 +14,53 @@ type Bot struct {
 	Bot    *hbot.Bot
 	DB     *bolt.DB
 	Random *rand.Rand // Initialized PRNG
+	Config Config
+}
+
+type Config struct {
+	NickservPass string   // Nickserv password
+	OperUser     string   // Username for server oper
+	OperPass     string   // Password for server oper
+	Channels     []string // slice of channels to connect to (must include #)
+	Nick         string   // nick to use
+	Server       string   // server:port for connections
+	SSL          bool     // Enable SSL for the connection
+	Admins       []string // slice of masks representing administrators
 }
 
 var b Bot = Bot{}
 
-func Run(server string, nick string, channels []string, ssl bool) {
-	chans := func(bot *hbot.Bot) {
-		bot.Channels = channels
-	}
-	sslOptions := func(bot *hbot.Bot) {
-		bot.SSL = ssl
-	}
-
-	irc, err := hbot.NewBot(server, nick, chans, sslOptions)
-	if err != nil {
-		log.Error(err.Error())
-		os.Exit(1)
-	}
-
+func Run(config Config) {
 	db, err := newDB()
 	if err != nil {
 		log.Error(err.Error())
 		os.Exit(1)
 	}
 
-	b.Bot = irc
 	b.DB = db
 	b.Random = rand.New(rand.NewSource(time.Now().UnixNano()))
+	b.Config = config
+
+	chans := func(bot *hbot.Bot) {
+		bot.Channels = b.Config.Channels
+	}
+	sslOptions := func(bot *hbot.Bot) {
+		bot.SSL = b.Config.SSL
+	}
+
+	irc, err := hbot.NewBot(b.Config.Server, b.Config.Nick, chans, sslOptions)
+	if err != nil {
+		log.Error(err.Error())
+		os.Exit(1)
+	}
+
+	b.Bot = irc
+	b.Bot.Logger.SetHandler(log.StreamHandler(os.Stdout, log.JsonFormat()))
 
 	// Triggers to run
 	// Passive triggers. Unskippable.
 	b.Bot.AddTrigger(TrackIdleUsers)
-
+	b.Bot.AddTrigger(OperLogin)
 	// Begin with skip prefix (!skip)
 	b.Bot.AddTrigger(SkipTrigger)
 	b.Bot.AddTrigger(InfoTrigger)
@@ -53,7 +68,6 @@ func Run(server string, nick string, channels []string, ssl bool) {
 	//b.Bot.AddTrigger(ReportIdleUsers)
 	b.Bot.AddTrigger(URLReaderTrigger)
 	b.Bot.AddTrigger(AbyssTrigger)
-	b.Bot.Logger.SetHandler(log.StreamHandler(os.Stdout, log.JsonFormat()))
 
 	// GOOOOOOO
 	defer b.DB.Close()

--- a/bitbot/login.go
+++ b/bitbot/login.go
@@ -1,0 +1,54 @@
+package bitbot
+
+import (
+	"fmt"
+	"github.com/whyrusleeping/hellabot"
+	"gopkg.in/sorcix/irc.v1"
+	"time"
+)
+
+var OperLogin = hbot.Trigger{
+	func(bot *hbot.Bot, m *hbot.Message) bool {
+		return m.Command == irc.RPL_MYINFO // message type 004
+	},
+
+	func(bot *hbot.Bot, m *hbot.Message) bool {
+		ns, ok := b.NickservLogin()
+		if ok {
+			bot.Msg("NickServ", ns)
+		}
+		time.Sleep(5 * time.Second)
+
+		op, ok := b.OperLogin()
+		if ok {
+			bot.Send(op)
+			time.Sleep(5 * time.Second)
+			b.GetOper()
+		}
+
+		return true
+	},
+}
+
+func (b Bot) OperLogin() (string, bool) {
+	//login := fmt.Sprintf("%+v", b.Config)
+	if b.Config.OperUser == "" || b.Config.OperPass == "" {
+		return "", false
+	}
+	login := fmt.Sprintf("OPER %s %s", b.Config.OperUser, b.Config.OperPass)
+	return login, true
+}
+
+func (b Bot) NickservLogin() (string, bool) {
+	if b.Config.NickservPass == "" {
+		return "", false
+	}
+	login := fmt.Sprintf("IDENTIFY %s", b.Config.NickservPass)
+	return login, true
+}
+
+func (b Bot) GetOper() {
+	for _, channel := range b.Config.Channels {
+		b.Bot.ChMode(b.Bot.Nick, channel, "+o")
+	}
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -23,18 +23,33 @@ package cmd
 import (
 	"github.com/bbriggs/bitbot/bitbot"
 	"github.com/spf13/cobra"
+	"log"
 )
 
 var server string
 var channels []string
 var nick string
 var ssl bool = false
+var nickservPass string
+var operUser string
+var operPass string
+var admins []string
 
 var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Run bitbot",
 	Run: func(cmd *cobra.Command, args []string) {
-		bitbot.Run(server, nick, channels, ssl)
+		c := bitbot.Config{
+			NickservPass: nickservPass,
+			OperUser:     operUser,
+			OperPass:     operPass,
+			Channels:     channels,
+			Nick:         nick,
+			Server:       server,
+			SSL:          ssl,
+		}
+		log.Println("Starting bitbot...")
+		bitbot.Run(c)
 	},
 }
 
@@ -43,7 +58,11 @@ func init() {
 
 	rootCmd.AddCommand(runCmd)
 	runCmd.Flags().StringVarP(&server, "server", "s", server, "target server")
+	runCmd.Flags().StringVarP(&nickservPass, "nickserv", "", nickservPass, "nickserv password")
+	runCmd.Flags().StringVarP(&operUser, "operUser", "", operUser, "oper username")
+	runCmd.Flags().StringVarP(&operPass, "operPass", "", operPass, "oper password")
 	runCmd.Flags().StringSliceVarP(&channels, "channels", "c", channels, "channels to join")
+	runCmd.Flags().StringSliceVarP(&channels, "admins", "", channels, "Hostmask of administrators")
 	runCmd.Flags().StringVarP(&nick, "nick", "n", nick, "nickname")
 	runCmd.Flags().BoolVarP(&ssl, "ssl", "", ssl, "enable ssl")
 


### PR DESCRIPTION
Added:
 - New flags for nickserv, oper user, and oper pass
   - If those values are empty, bitbot will not attempt to invoke them
 - Attempt to get oper in channels joined at start _only if a oper credentials were passed_
 - Updated `Run()` public method to new signature. Use new `bitbot.Config` struct as only argument now.