### PR TITLE
Add a help plugin

### DIFF
--- a/bitbot/bot.go
+++ b/bitbot/bot.go
@@ -91,7 +91,8 @@ func Run(config Config) {
 	b.Bot.AddTrigger(unloadTrigger)
 	b.Bot.AddTrigger(NickTakenTrigger)
 	for _, trigger := range config.Plugins {
-		b.Bot.AddTrigger(trigger)
+		log.Info(trigger.Name() + " loaded")
+		b.RegisterTrigger(trigger)
 	}
 
 	b.Bot.Logger.SetHandler(log.StreamHandler(os.Stdout, log.JsonFormat()))

--- a/bitbot/help.go
+++ b/bitbot/help.go
@@ -1,0 +1,19 @@
+package bitbot
+
+import (
+	"github.com/whyrusleeping/hellabot"
+	"strings"
+)
+
+var HelpTrigger = NamedTrigger{
+	ID: "help",
+	Condition: func(irc *hbot.Bot, m *hbot.Message) bool {
+		return m.Command == "PRIVMSG" && strings.TrimSpace(m.Content) == "!help"
+
+	},
+	Action: func(irc *hbot.Bot, m *hbot.Message) bool {
+		triggers := b.ListTriggers()
+		irc.Reply(m, "Currently loaded plugins: "+strings.Join(triggers, ", "))
+		return true
+	},
+}

--- a/bitbot/loadtest.go
+++ b/bitbot/loadtest.go
@@ -59,13 +59,8 @@ var listTriggers = NamedTrigger{
 		return m.Command == "PRIVMSG" && strings.TrimSpace(m.Content) == "!triggers" && b.isAdmin(m)
 	},
 	Action: func(irc *hbot.Bot, m *hbot.Message) bool {
-		var triggers []string
-		irc.Reply(m, "Listing registered triggers...")
-		b.triggers.Range(func(k interface{}, v interface{}) bool {
-			triggers = append(triggers, k.(string))
-			return true
-		})
-		irc.Reply(m, strings.Join(triggers[:], ", "))
+		triggers := b.ListTriggers()
+		irc.Reply(m, strings.Join(triggers, ", "))
 		return true
 	},
 }

--- a/bitbot/triggerConditions_test.go
+++ b/bitbot/triggerConditions_test.go
@@ -15,6 +15,7 @@ func TestBasicNamedTriggers(t *testing.T) {
 		"Nickname is already in use.": NickTakenTrigger,
 		"!tableflip":                  TableFlipTrigger,
 		"!unflip":                     TableUnflipTrigger,
+		"!help":                       HelpTrigger,
 	}
 	b := makeMockBot("bitbot")
 

--- a/bitbot/users.go
+++ b/bitbot/users.go
@@ -10,11 +10,12 @@ import (
 	log "gopkg.in/inconshreveable/log15.v2"
 )
 
-var TrackIdleUsers = hbot.Trigger{
-	func(irc *hbot.Bot, m *hbot.Message) bool {
+var TrackIdleUsers = NamedTrigger{
+	ID: "trackIdleUsers",
+	Condition: func(irc *hbot.Bot, m *hbot.Message) bool {
 		return m.Command == "PRIVMSG"
 	},
-	func(irc *hbot.Bot, m *hbot.Message) bool {
+	Action: func(irc *hbot.Bot, m *hbot.Message) bool {
 		err := b.TrackIdleUsers(m)
 		if err != nil {
 			log.Error(err.Error())
@@ -36,11 +37,12 @@ func (b Bot) TrackIdleUsers(m *hbot.Message) error {
 	return err
 }
 
-var ReportIdleUsers = hbot.Trigger{
-	func(irc *hbot.Bot, m *hbot.Message) bool {
+var ReportIdleUsers = NamedTrigger{
+	ID: "reportIdleUsers",
+	Condition: func(irc *hbot.Bot, m *hbot.Message) bool {
 		return m.Command == "PRIVMSG" && strings.HasPrefix(m.Content, "!idle")
 	},
-	func(irc *hbot.Bot, m *hbot.Message) bool {
+	Action: func(irc *hbot.Bot, m *hbot.Message) bool {
 		args := strings.Split(m.Content, " ")
 		if len(args) < 2 {
 			irc.Reply(m, "Please specify a nick to lookup")

--- a/bitbot/util.go
+++ b/bitbot/util.go
@@ -36,6 +36,18 @@ type ACL struct {
 	Rejected []string
 }
 
+// ListTriggers gets all trigger IDs currently registered to the bot
+func (b *Bot) ListTriggers() []string {
+	var triggers []string
+	b.triggerMutex.RLock()
+	defer b.triggerMutex.RUnlock()
+
+	for k, _ := range b.triggers {
+		triggers = append(triggers, k)
+	}
+	return triggers
+}
+
 func int64ToByte(i int64) []byte {
 	b := make([]byte, 8)
 	binary.LittleEndian.PutUint64(b, uint64(i))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,6 +52,7 @@ var pluginMap = map[string]bitbot.NamedTrigger{
 	"roll":           bitbot.RollTrigger,
 	"decisions":      bitbot.DecisionsTrigger,
 	"beef":           bitbot.BeefyTrigger,
+	"help":           bitbot.HelpTrigger,
 }
 
 // rootCmd represents the base command when called without any subcommands

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,7 +28,6 @@ import (
 	"github.com/bbriggs/bitbot/bitbot"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/whyrusleeping/hellabot"
 )
 
 const VERSION = ""
@@ -44,7 +43,7 @@ var (
 	operPass string
 )
 
-var pluginMap = map[string]hbot.Handler{
+var pluginMap = map[string]bitbot.NamedTrigger{
 	"trackIdleUsers": bitbot.TrackIdleUsers,
 	"skip":           bitbot.SkipTrigger,
 	"info":           bitbot.InfoTrigger,
@@ -61,7 +60,7 @@ var rootCmd = &cobra.Command{
 	Use:     "bitbot [flags]",
 	Short:   "A Golang IRC bot powered by Hellabot",
 	Run: func(cmd *cobra.Command, args []string) {
-		var plugins []hbot.Handler
+		var plugins []bitbot.NamedTrigger
 		for _, plugin := range viper.GetStringSlice("plugins") {
 			if p, ok := pluginMap[plugin]; ok {
 				plugins = append(plugins, p)


### PR DESCRIPTION
Took the opportunity to fix some things along the way...

In order to get this done correctly, we had to iterate over the private map of triggers. There was no good reason to use `sync.Map` over a mutex + plain map, so I also switched that while properly registering triggers.

Furthermore, using named triggers _everywhere_ now and will continue to use those whenever possible.

Also added a ListTrigger utility method.

Finally, included the help trigger itself.