### PR TITLE
MarkovInit (Issue #81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    - Bitbot can now flip and unflip the table for you ! (#68, m-242)
    - Better tests for all triggers with conditions based on inbound messages
    - Add tarot card draw module (#73, skidd0)
+   - Add markov chain reset/init module (#81, parsec)
 
 ### Fixed
    - Fixed the plugin links's tests (#53, @m-242)

--- a/bitbot/markov.go
+++ b/bitbot/markov.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math/rand"
-	"strings"
 	"net/http"
+	"strings"
 
 	"github.com/mb-14/gomarkov"
 	"github.com/whyrusleeping/hellabot"
@@ -40,7 +40,7 @@ var MarkovResponseTrigger = NamedTrigger{
 }
 
 var MarkovInitTrigger = NamedTrigger{
-	ID: "markovInit",
+	ID:   "markovInit",
 	Help: "Resets markov chain to a fresh chain, or bootstraps it with sample texts. Usage: !markov reset, !markov init",
 	Condition: func(irc *hbot.Bot, m *hbot.Message) bool {
 		return m.Command == "PRIVMSG" && strings.HasPrefix(m.Content, "!markov ")
@@ -50,7 +50,7 @@ var MarkovInitTrigger = NamedTrigger{
 		if len(cmd) < 2 {
 			return false
 		}
-		switch cmd[1]{
+		switch cmd[1] {
 		case "reset":
 			// do stuff
 			b.mChain = gomarkov.NewChain(1)
@@ -64,7 +64,6 @@ var MarkovInitTrigger = NamedTrigger{
 			return false
 		}
 	},
-	
 }
 
 func generateBabble(chain *gomarkov.Chain) string {

--- a/bitbot/markov.go
+++ b/bitbot/markov.go
@@ -48,7 +48,7 @@ var MarkovInitTrigger = NamedTrigger{
 	Action: func(irc *hbot.Bot, m *hbot.Message) bool {
 		cmd := strings.Split(m.Content, " ")
 		if len(cmd) < 2 {
-			irc.Reply(m, MarkovInitTrigger.Help)
+			irc.Reply(m, "Usage: !markov reset, !markov init")
 			return true
 		}
 		switch cmd[1] {

--- a/bitbot/markov.go
+++ b/bitbot/markov.go
@@ -1,7 +1,6 @@
 package bitbot
 
 import (
-	"fmt"
 	"log"
 	"io/ioutil"
 	"math/rand"
@@ -65,6 +64,7 @@ var MarkovInitTrigger = NamedTrigger{
 		default:
 			return true
 		}
+		return true
 	},
 }
 

--- a/bitbot/markov.go
+++ b/bitbot/markov.go
@@ -52,15 +52,17 @@ var MarkovInitTrigger = NamedTrigger{
 		}
 		switch cmd[1] {
 		case "reset":
-			// do stuff
 			b.mChain = gomarkov.NewChain(1)
 			return true
 		case "init":
-			// do other stuff
 			b.mChain = gomarkov.NewChain(1)
-			return markovInit(b.mChain)
+			if markovInit(b.mChain) == false {
+				irc.Reply(m, "Markov initialization failed.")
+			} else {
+				irc.Reply(m, "Markov initialization succeeded.")
+			}
+			return true
 		default:
-			// didn't recognize the subcommands
 			return false
 		}
 	},
@@ -80,15 +82,18 @@ func markovInit(chain *gomarkov.Chain) bool {
 		"https://gist.githubusercontent.com/bbriggs/f63340a3ed1a1439b6f3f8d619eacac1/raw/1f363d500226c55bab735fe59074f06721348546/world_factbook.txt",
 		"https://gist.githubusercontent.com/parsec/2f4d4edf55336c0a2994cfcf951a8ea7/raw/4b66c99f1879b927ebc2b2ffb8fdd39dc9a4f7d2/SnwCrsh"}
 
-	i := 0
-	for i <= len(sources) {
-		resp, err := http.Get(sources[i])
+	for _, link := range(sources) {
+		resp, err := http.Get(link)
 		if err != nil {
 			fmt.Println(err)
 			return false
 		}
 		defer resp.Body.Close()
 		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			fmt.Println(err)
+			return false
+		}
 		bodyString := string(body)
 		markovAdd(bodyString, chain)
 	}
@@ -100,5 +105,4 @@ func markovAdd(text string, chain *gomarkov.Chain) {
 	b.markovMutex.Lock()
 	b.mChain.Add(strings.Split(text, " "))
 	b.markovMutex.Unlock()
-
 }

--- a/bitbot/markov.go
+++ b/bitbot/markov.go
@@ -2,6 +2,7 @@ package bitbot
 
 import (
 	"fmt"
+	"log"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
@@ -48,22 +49,21 @@ var MarkovInitTrigger = NamedTrigger{
 	Action: func(irc *hbot.Bot, m *hbot.Message) bool {
 		cmd := strings.Split(m.Content, " ")
 		if len(cmd) < 2 {
-			return false
+			irc.Reply(m, MarkovInitTrigger.Help)
+			return true
 		}
 		switch cmd[1] {
 		case "reset":
 			b.mChain = gomarkov.NewChain(1)
-			return true
 		case "init":
 			b.mChain = gomarkov.NewChain(1)
-			if markovInit(b.mChain) == false {
-				irc.Reply(m, "Markov initialization failed.")
-			} else {
+			if markovInit(b.mChain) {
 				irc.Reply(m, "Markov initialization succeeded.")
+			} else {
+				irc.Reply(m, "Markov initialization failed.")
 			}
-			return true
 		default:
-			return false
+			return true
 		}
 	},
 }
@@ -85,13 +85,13 @@ func markovInit(chain *gomarkov.Chain) bool {
 	for _, link := range(sources) {
 		resp, err := http.Get(link)
 		if err != nil {
-			fmt.Println(err)
+			log.Println(err)
 			return false
 		}
 		defer resp.Body.Close()
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			fmt.Println(err)
+			log.Println(err)
 			return false
 		}
 		bodyString := string(body)

--- a/bitbot/markov.go
+++ b/bitbot/markov.go
@@ -1,6 +1,8 @@
 package bitbot
 
 import (
+	"fmt"
+	"io/ioutil"
 	"math/rand"
 	"strings"
 	"net/http"
@@ -20,7 +22,7 @@ var MarkovTrainerTrigger = NamedTrigger{
 			// Initialize markov chain
 			b.mChain = gomarkov.NewChain(1)
 		}
-		markovAdd(b.mChain)
+		markovAdd(m.Content, b.mChain)
 		return false
 	},
 }
@@ -41,9 +43,9 @@ var MarkovInitTrigger = NamedTrigger{
 	ID: "markovInit",
 	Help: "Resets markov chain to a fresh chain, or bootstraps it with sample texts. Usage: !markov reset, !markov init",
 	Condition: func(irc *hbot.Bot, m *hbot.Message) bool {
-		return m.Command == "PRIVMSG" && strings.HasPrefix(m.Content == "!markov ")
+		return m.Command == "PRIVMSG" && strings.HasPrefix(m.Content, "!markov ")
 	},
-	Action: func(irc *hbot.bot, m *hbot.Message) bool {
+	Action: func(irc *hbot.Bot, m *hbot.Message) bool {
 		cmd := strings.Split(m.Content, " ")
 		if len(cmd) < 2 {
 			return false
@@ -56,13 +58,12 @@ var MarkovInitTrigger = NamedTrigger{
 		case "init":
 			// do other stuff
 			b.mChain = gomarkov.NewChain(1)
-			markovInit(b.mChain)
-			return true
+			return markovInit(b.mChain)
 		default:
 			// didn't recognize the subcommands
 			return false
 		}
-	}
+	},
 	
 }
 
@@ -75,8 +76,24 @@ func generateBabble(chain *gomarkov.Chain) string {
 	return strings.Join(tokens[1:len(tokens)-1], " ")
 }
 
-func markovInit(chain *gomarkov.Chain) string {
-	//todo
+func markovInit(chain *gomarkov.Chain) bool {
+	var sources = [3]string{"https://gist.githubusercontent.com/bbriggs/60e907f3571a1ca7c41cd99f78052d78/raw/fe6d0bd96ee97c9b5df2794ae683d24a404b4433/bible.txt",
+		"https://gist.githubusercontent.com/bbriggs/f63340a3ed1a1439b6f3f8d619eacac1/raw/1f363d500226c55bab735fe59074f06721348546/world_factbook.txt",
+		"https://gist.githubusercontent.com/parsec/2f4d4edf55336c0a2994cfcf951a8ea7/raw/4b66c99f1879b927ebc2b2ffb8fdd39dc9a4f7d2/SnwCrsh"}
+
+	i := 0
+	for i <= len(sources) {
+		resp, err := http.Get(sources[i])
+		if err != nil {
+			fmt.Println(err)
+			return false
+		}
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+		bodyString := string(body)
+		markovAdd(bodyString, chain)
+	}
+	return true
 }
 
 // wrapper for b.mChain.Add that includes file lock/unlock
@@ -84,4 +101,5 @@ func markovAdd(text string, chain *gomarkov.Chain) {
 	b.markovMutex.Lock()
 	b.mChain.Add(strings.Split(text, " "))
 	b.markovMutex.Unlock()
+
 }

--- a/bitbot/triggerConditions_test.go
+++ b/bitbot/triggerConditions_test.go
@@ -18,6 +18,8 @@ func TestBasicNamedTriggers(t *testing.T) {
 		"!help":                       HelpTrigger,
 		"!8ball":                      Magic8BallTrigger,
 		"!babble":                     MarkovResponseTrigger,
+		"!markov reset":			   MarkovInitTrigger,
+		"!markov init":				   MarkovInitTrigger,
 	}
 	b := makeMockBot("bitbot")
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.12
 
 require (
 	github.com/bbriggs/quotes v0.0.0-20190225011706-ef48dc0c0ec7
-	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/inconshreveable/log15 v0.0.0-20180818164646-67afb5ed74ec // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/justinian/dice v0.0.0-20170728002755-6a18b51d929c
@@ -12,8 +11,6 @@ require (
 	github.com/mattn/go-colorable v0.1.1 // indirect
 	github.com/mattn/go-isatty v0.0.7 // indirect
 	github.com/mb-14/gomarkov v0.0.0-20190125094512-044dd0dcb5e7
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/mudler/sendfd v0.0.0-20150620134918-f0fc74c13877 // indirect
 	github.com/pelletier/go-toml v1.4.0 // indirect
 	github.com/prometheus/client_golang v1.1.0


### PR DESCRIPTION
Created a wrapper for `markovAdd()` that wraps the mutex lock, addition to the markov chain and mutex unlock in one function.

Also created a new trigger, `!markov` which accepts the parameters `reset` and `init`. `reset` creates a new, blank markov chain in place of the old one. `init` uses hardcoded sample sources to train the new markov chain.