### PR TITLE
Add and use JoinAllChannels method

### DIFF
--- a/bitbot/bot.go
+++ b/bitbot/bot.go
@@ -123,5 +123,4 @@ func Run(config Config) {
 	// GOOOOOOO
 	defer b.DB.Close()
 	b.Bot.Run()
-
 }

--- a/bitbot/login.go
+++ b/bitbot/login.go
@@ -16,6 +16,9 @@ var OperLogin = hbot.Trigger{
 		ns, ok := b.NickservLogin()
 		if ok {
 			bot.Msg("NickServ", ns)
+			time.Sleep(5 * time.Second)
+			// To get into those pesky +r channels
+			b.JoinAllChannels()
 		}
 		time.Sleep(5 * time.Second)
 

--- a/bitbot/util.go
+++ b/bitbot/util.go
@@ -3,9 +3,11 @@ package bitbot
 import (
 	"encoding/binary"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/whyrusleeping/hellabot"
 	"gopkg.in/sorcix/irc.v1"
-	"time"
 )
 
 // NamedTrigger is a local re-implementation of hbot.Trigger to support unique names
@@ -47,6 +49,21 @@ func (b *Bot) ListTriggers() []string {
 		triggers = append(triggers, k)
 	}
 	return triggers
+}
+
+// JoinAllChannels attempts to rejoin all channels defined in the bot's config
+// This is a workaround for the joining channels which may be +r before the bot is identified
+func (b *Bot) JoinAllChannels() {
+	for _, channel := range b.Config.Channels {
+		splitchan := strings.SplitN(channel, ":", 2)
+		if len(splitchan) == 2 {
+			channel = splitchan[0]
+			password := splitchan[1]
+			b.Bot.Send(fmt.Sprintf("JOIN %s %s", channel, password))
+		} else {
+			b.Bot.Send(fmt.Sprintf("JOIN %s", channel))
+		}
+	}
 }
 
 func int64ToByte(i int64) []byte {


### PR DESCRIPTION
There's a timing issue where the bot attempts to join channels before it identifies with services.

This is a quick hack to get it to join those channels while I work with the upstream to figure out a solution.

Signed-off-by: Bren Briggs <code@fraq.io>