### PR TITLE
Prevent MarkovTrainer from training on links and commands

### DIFF
--- a/bitbot/decisions.go
+++ b/bitbot/decisions.go
@@ -23,7 +23,7 @@ var DecisionsTrigger = NamedTrigger{
 			r = "Choose what?"
 		}
 		irc.Reply(m, r)
-		return false
+		return true
 	},
 }
 

--- a/bitbot/dice.go
+++ b/bitbot/dice.go
@@ -26,7 +26,7 @@ var RollTrigger = NamedTrigger{
 			resp = DICE_USAGE
 		}
 		irc.Reply(m, resp)
-		return false
+		return true
 	},
 }
 

--- a/bitbot/messageCounter.go
+++ b/bitbot/messageCounter.go
@@ -13,6 +13,6 @@ var MessageCounterTrigger = NamedTrigger{
 	},
 	Action: func(irc *hbot.Bot, m *hbot.Message) bool {
 		b.counters["messageCounter"].WithLabelValues(m.To, m.Name).Inc()
-		return true
+		return false
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,10 +57,10 @@ var pluginMap = map[string]bitbot.NamedTrigger{
 	"help":           bitbot.HelpTrigger,
 	"8ball":          bitbot.Magic8BallTrigger,
 	"tarot":          bitbot.TarotTrigger,
-	"markovTrainer":  bitbot.MarkovTrainerTrigger,
 	"markovResponse": bitbot.MarkovResponseTrigger,
 	"markovInit":     bitbot.MarkovInitTrigger,
 	"troll":          bitbot.TrollLauncherTrigger,
+	"markovTrainer":  bitbot.MarkovTrainerTrigger,
 }
 
 // rootCmd represents the base command when called without any subcommands


### PR DESCRIPTION
Consume messages and move the trigger to the end of the loaded plugin order to prevent it from training on commands. 