### PR TITLE
removing code anti-patterns

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,8 @@
+version = 1
+
+[[analyzers]]
+name = "go"
+enabled = true
+
+  [analyzers.meta]
+  import_path = "github.com/staticnotdynamic/bitbot"

--- a/bitbot/flipTable.go
+++ b/bitbot/flipTable.go
@@ -8,7 +8,7 @@ var TableFlipTrigger = NamedTrigger{
 	ID:   "tableflip",
 	Help: "Flip a table. Usage: !tableflip",
 	Condition: func(irc *hbot.Bot, m *hbot.Message) bool {
-		match := ("!tableflip" == m.Content)
+		match := (m.Content == "!tableflip")
 		return m.Command == "PRIVMSG" && match
 	},
 	Action: func(irc *hbot.Bot, m *hbot.Message) bool {
@@ -20,7 +20,7 @@ var TableFlipTrigger = NamedTrigger{
 var TableUnflipTrigger = NamedTrigger{
 	ID: "unflip",
 	Condition: func(irc *hbot.Bot, m *hbot.Message) bool {
-		match := ("!unflip" == m.Content)
+		match := (m.Content == "!unflip")
 		return m.Command == "PRIVMSG" && match
 	},
 	Action: func(irc *hbot.Bot, m *hbot.Message) bool {

--- a/bitbot/util.go
+++ b/bitbot/util.go
@@ -66,7 +66,7 @@ func (b *Bot) ListTriggers() []string {
 	b.triggerMutex.RLock()
 	defer b.triggerMutex.RUnlock()
 
-	for k, _ := range b.triggers {
+	for k := range b.triggers {
 		triggers = append(triggers, k)
 	}
 	return triggers

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -164,7 +164,7 @@ func init() {
 
 	// All plugins enabled by default
 	var defaultPlugins []string
-	for plugin, _ := range pluginMap {
+	for plugin := range pluginMap {
 		defaultPlugins = append(defaultPlugins, plugin)
 	}
 	viper.SetDefault("nick", "bitbot")


### PR DESCRIPTION
These are auto fixes provided by deepsource's Go static code analyzer. Other fixes require manual intervention as described in #157 

## Yoda Conditions
Yoda conditions are conditions written in the form of `literal CMP variable`, where CMP is a comparator.
For example, `"" == msg` is a Yoda condition.

Yoda conditions are used in languages where assignments can be made in places where comparisons are made, to avoid bugs.
For example, `if (42 == x) {}` is more idiomatic in C, as it avoids the accidental `if (x = 42)`, if it were written the other way round.

However, assignments are not expressions in Go, and hence, it is idiomatic to write `x == 42`.