### PR TITLE
Fixing small incoherences

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,7 +76,7 @@ var pluginMap = map[string]bitbot.NamedTrigger{
 	"ipinfo":         bitbot.IPinfoTrigger,
 	"urbd":           bitbot.UrbanDictionaryTrigger,
 	"reminder":       bitbot.ReminderTrigger,
-	"lenny":          bitbot.LennyTrigger,
+	"lennyface":      bitbot.LennyTrigger,
 }
 
 // rootCmd represents the base command when called without any subcommands


### PR DESCRIPTION
For some reason the lennyface trigger stopped working. While investigating, I noticed incoherences between the trigger id and it's name in the plugin map. I doubt it will fix the lenny trigger to change that, but it's never bad to reduce incoherences.