### PR TITLE
Fix database access

### DIFF
--- a/bitbot/bot.go
+++ b/bitbot/bot.go
@@ -60,19 +60,23 @@ var b Bot = Bot{}
 
 func (b *Bot) RegisterTrigger(t NamedTrigger) {
 	var err error
-
 	b.triggerMutex.Lock()
-	b.triggers[t.Name()] = t
-	b.triggerMutex.Unlock()
-	b.Bot.AddTrigger(t)
+	defer b.triggerMutex.Unlock()
 
+	// Since the Init field has been added recently, we need to test if it exists
 	if t.Init != nil {
 		err = t.Init()
 	}
 
+	// If the init ran correctly, we register the trigger
 	if err != nil {
 		b.Config.Logger.Error("Trigger " + t.Name() + " failed to initialize: " + err.Error())
+	} else {
+		b.triggers[t.Name()] = t
+		b.Bot.AddTrigger(t)
+		b.Config.Logger.Info("Loaded" + t.Name())
 	}
+
 }
 
 func (b *Bot) FetchTrigger(name string) (NamedTrigger, bool) {
@@ -135,7 +139,7 @@ func Run(config Config) {
 	b.Bot.AddTrigger(NickTakenTrigger)
 	b.Bot.AddTrigger(NickRecoverTrigger)
 	for _, trigger := range config.Plugins {
-		config.Logger.Info(trigger.Name() + " loaded")
+		config.Logger.Info("Loading" + trigger.Name())
 		b.RegisterTrigger(trigger)
 	}
 

--- a/bitbot/reminder.go
+++ b/bitbot/reminder.go
@@ -10,13 +10,13 @@ import (
 	"github.com/whyrusleeping/hellabot"
 )
 
-var ( //nolint
+var (
 	location   *time.Location
 	timeFormat string
 )
 
 // ReminderEvent : The Gorm struct that represents an event in the DB.
-type ReminderEvent struct { //nolint
+type ReminderEvent struct {
 	ID          int `gorm:"unique;AUTO_INCREMENT;PRIMARY_KEY"`
 	Channel     string
 	Author      string

--- a/bitbot/reminder.go
+++ b/bitbot/reminder.go
@@ -37,6 +37,17 @@ func (e *wrongFormatError) Error() string {
 var ReminderTrigger = NamedTrigger{ //nolint:gochecknoglobals,golint
 	ID:   "reminder",
 	Help: "Set up events and remind them to concerned people. Usage: !remind list|time|add|remove|join|part",
+	Init: func() error {
+		var err error
+
+		location, err = time.LoadLocation("UTC")
+		if err != nil {
+			b.Config.Logger.Error("Reminder : Couldn't load UTC timezone", err.Error())
+			return err
+		}
+
+		return b.DB.AutoMigrate(&ReminderEvent{}).Error
+	},
 	Condition: func(irc *hbot.Bot, m *hbot.Message) bool {
 		return m.Command == "PRIVMSG" && strings.HasPrefix(m.Trailing, "!remind")
 	},
@@ -66,18 +77,6 @@ var ReminderTrigger = NamedTrigger{ //nolint:gochecknoglobals,golint
 			irc.Reply(m, "Wrong argument")
 		}
 		return true
-	},
-	Init: func() error {
-		var err error
-
-		location, err = time.LoadLocation("UTC")
-		if err != nil {
-			b.Config.Logger.Error("Reminder : Couldn't load UTC timezone", err.Error())
-			return err
-		}
-
-		b.DB.AutoMigrate(&ReminderEvent{})
-		return nil
 	},
 }
 
@@ -115,7 +114,9 @@ func addEvent(message *hbot.Message, bot *hbot.Bot) string {
 		Time:        timeOfEvent,
 		People:      fmt.Sprintf("%s ", author)}
 	b.DB.NewRecord(event)
-	b.DB.Create(&event)
+	if err := b.DB.Create(&event); err != nil {
+		return "Something went wrong"
+	}
 
 	// Launch a background routine that will HL interested people and clean the DB.
 	// The magic number 2 is indeed completely arbitrary, but we need it anyway.
@@ -156,7 +157,9 @@ func removeEvent(message *hbot.Message) string {
 		return "Wrong command. format is : !remind remove [ID]"
 	}
 
-	b.DB.Where("ID = ? AND Author = ?", id, message.Name).Take(&event)
+	if err := b.DB.Where("ID = ? AND Author = ?", id, message.Name).Take(&event); err != nil {
+		return "Something went wrong, no access to database"
+	}
 
 	// Feedback Message construction
 	var feedbackMessage string
@@ -166,7 +169,9 @@ func removeEvent(message *hbot.Message) string {
 			event.Description)
 
 		// Delete
-		b.DB.Delete(&event)
+		if err := b.DB.Delete(&event); err != nil {
+			return "Something went wrong, no access to database"
+		}
 	} else {
 		feedbackMessage = "No event you own with that ID"
 	}
@@ -216,14 +221,20 @@ func joinEvent(message *hbot.Message) string {
 		return "Wrong command. format is : !remind join [ID]"
 	}
 
-	b.DB.Where("ID = ?", id).Take(&event)
+	if err := b.DB.Where("ID = ?", id).Take(&event); err != nil {
+		return "Something went wrong, no access to database"
+	}
 
 	if strings.Contains(event.People, message.Name) {
-		b.DB.Save(&event)
+		if err := b.DB.Save(&event); err != nil {
+			return "Something went wrong, no access to database"
+		}
 		return "You already subscribed to this event"
 	}
 	event.People = fmt.Sprintf("%s%s ", event.People, message.Name)
-	b.DB.Save(&event)
+	if err := b.DB.Save(&event); err != nil {
+		return "Something went wrong, no access to database"
+	}
 
 	feedback := fmt.Sprintf("Added %s to \"%s\"",
 		message.Name,
@@ -240,7 +251,9 @@ func partEvent(message *hbot.Message) string {
 		return "Wrong command. format is : !remind part [ID]"
 	}
 
-	b.DB.Where("ID = ?", id).Take(&event)
+	if err := b.DB.Where("ID = ?", id).Take(&event); err != nil {
+		return "Something went wrong, no access to database"
+	}
 	defer b.DB.Save(&event)
 
 	if event.Author == message.Name {

--- a/bitbot/reminder.go
+++ b/bitbot/reminder.go
@@ -10,13 +10,13 @@ import (
 	"github.com/whyrusleeping/hellabot"
 )
 
-var ( //nolint:gochecknoglobals,golint
+var ( //nolint
 	location   *time.Location
 	timeFormat string
 )
 
 // ReminderEvent : The Gorm struct that represents an event in the DB.
-type ReminderEvent struct { //nolint:gochecknoglobals,golint
+type ReminderEvent struct { //nolint
 	ID          int `gorm:"unique;AUTO_INCREMENT;PRIMARY_KEY"`
 	Channel     string
 	Author      string


### PR DESCRIPTION
The crash at `!reminder list` came from two things, the database not being accessible and improper error handling in reminder.

The triggers whose `Init()` function fails won't register anymore, so one should leverage it to make sure used features are accessible.