### PR TITLE
Better docker-build.sh

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,13 +1,14 @@
 #! /bin/sh
 
 # Get latest commit, tag, and branch we build on
-export GIT_COMMIT=$(git rev-parse --short HEAD) 
-export GIT_TAG=$(git describe --abbrev=0 --tags)
-export GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD) 
+GIT_COMMIT=$(git rev-parse --short HEAD) 
+GIT_TAG=$(git describe --abbrev=0 --tags)
+GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD) 
+export GIT_COMMIT GIT_TAG GIT_BRANCH
 
-echo $GIT_COMMIT
-echo $GIT_TAG
-echo $GIT_BRANCH
+echo "$GIT_COMMIT"
+echo "$GIT_TAG"
+echo "$GIT_BRANCH"
 
 XFLAGS="-X github.com/bbriggs/bitbot/bitbot.GitCommit=$GIT_COMMIT -X github.com/bbriggs/bitbot/bitbot.GitBranch=$GIT_BRANCH -X github.com/bbriggs/bitbot/bitbot.GitTag=$GIT_TAG"
 
@@ -17,4 +18,5 @@ if [ $? -eq 0 ]; then
 	echo -e "Compiled bitbot:\n\tGit tag: $GIT_TAG\n\tGit commit: $GIT_COMMIT\n\tGit branch: $GIT_BRANCH\n"
 else
 	echo "The build failed"
+	exit 1
 fi


### PR DESCRIPTION
Running `exit 1` at build fail to avoid docker caching it, and ran `shellcheck` on the script.