### PR TITLE
Nick Shuffle trigger and logic

### DIFF
--- a/bitbot/nick.go
+++ b/bitbot/nick.go
@@ -8,7 +8,7 @@ import (
 
 var NickTakenTrigger = NamedTrigger{ //nolint:gochecknoglobals,golint
 	ID:   "nick",
-	Help: "Avoids nick collisions by renaming the bot if the nick is already taken.",
+	Help: "Avoids nick collisions by renaming the bot if the nick is already taken. Not recommended to use with nickRandomizer.",
 	Condition: func(irc *hbot.Bot, m *hbot.Message) bool {
 		/* get the host's name by cutting the port number, and making sure that the message comes from host */
 		var comesFromHost = (m.From == strings.Split(irc.Host, ":")[0])
@@ -44,6 +44,24 @@ var ManualNickRecoverTrigger = NamedTrigger{ //nolint:gochecknoglobals,golint
 	},
 	Action: func(irc *hbot.Bot, m *hbot.Message) bool {
 		tryNickRecovery(irc)
+		return false
+	},
+}
+
+var NickRandomizerTrigger = NamedTrigger{ //nolint:gochecknoglobals,golint
+	ID:   "nickRandomizer",
+	Help: "Avoids nick collisions by renaming the bot to a random nick from the database if the nick is already taken. Not recommended to use with NickTakenTrigger.",
+	Condition: func(irc *hbot.Bot, m *hbot.Message) bool {
+		/* get the host's name by cutting the port number, and making sure that the message comes from host */
+		var comesFromHost = (m.From == strings.Split(irc.Host, ":")[0])
+
+		var nickTaken = strings.Contains(m.Content, "Nickname is already in use")
+
+		return comesFromHost && nickTaken
+	},
+	Action: func(irc *hbot.Bot, m *hbot.Message) bool {
+		nick, err :=
+			irc.SetNick(irc.Nick + "_")
 		return false
 	},
 }

--- a/bitbot/nick.go
+++ b/bitbot/nick.go
@@ -60,8 +60,13 @@ var NickRandomizerTrigger = NamedTrigger{ //nolint:gochecknoglobals,golint
 		return comesFromHost && nickTaken
 	},
 	Action: func(irc *hbot.Bot, m *hbot.Message) bool {
-		nick, err :=
+		nick, err := getRandomNick()
+		if err != nil {
+			b.Config.Logger.Error("nickRandomizer: Unable to get a new nickname")
+			b.Config.Logger.Error("nickRandomizer: Falling back to underscore behavior")
 			irc.SetNick(irc.Nick + "_")
+		}
+		irc.SetNick(nick)
 		return false
 	},
 }

--- a/bitbot/nickShuffle.go
+++ b/bitbot/nickShuffle.go
@@ -17,44 +17,48 @@ var (
 
 // ReminderEvent : The Gorm struct that represents an event in the DB.
 type NickList struct {
-	ID   int    `gorm:"unique;AUTO_INCREMENT;PRIMARY_KEY"`
-	Nick string `gorm:"unique"`
+	ID   int    `gorm:"unique;AUTO_INCREMENT;PRIMARY_KEY"` // Primary Key
+	Nick string `gorm:"unique"`                            // Nickname to use
+	From string // Submitter of the nickname
 }
 
 var NickShuffleTrigger = NamedTrigger{ //nolint:gochecknoglobals,golint
 	ID:   "nickShuffle",
-	Help: "Add a nick to my shuffle. Usage: !nick add|drop <nick>",
+	Help: "Add a nick to my shuffle. Usage: !nick add <nick>",
 	Init: func() error {
 		return b.DB.AutoMigrate(&NickList{}).Error
 	},
 	Condition: func(irc *hbot.Bot, m *hbot.Message) bool {
-		return m.Command == "PRIVMSG" && strings.HasPrefix(m.Trailing, "!remind")
+		return m.Command == "PRIVMSG" && strings.HasPrefix(m.Trailing, "!nick add <nickname>")
 	},
 	Action: func(irc *hbot.Bot, m *hbot.Message) bool {
-		timeFormat = "2006-01-02 15:04"
-
-		splitMSG := strings.Split(m.Content, " ")
-		if len(splitMSG) < 2 {
-			irc.Reply(m, "Not enough arguments provided")
-			return true
-		}
-
-		switch splitMSG[1] {
-		case "time":
-			irc.Reply(m, getTime())
-		case "add":
-			irc.Reply(m, addEvent(m, irc))
-		case "remove":
-			irc.Reply(m, removeEvent(m))
-		case "list":
-			irc.Reply(m, listEvents(m, irc))
-		case "join":
-			irc.Reply(m, joinEvent(m))
-		case "part":
-			irc.Reply(m, partEvent(m))
-		default:
-			irc.Reply(m, "Wrong argument")
+		ok, err := addNickToDB(m)
+		if !ok {
+			irc.Reply("Looks like something went wrong.")
+			irc.Reply(err.Error())
 		}
 		return true
 	},
+}
+
+func addNickToDB(m *hbot.Message) (bool, error) {
+	// split message, error out if too short
+	splitMsg := strings.Split(m.Content, " ")
+	if len(splitMsg) < 3 {
+		return false, fmt.Errorf("Not enough arguments. See !help nickShuffle")
+	}
+
+	// grab nick, error out if invalid
+	newNick := NickList{
+		Nick: splitMsg[2],
+		From: m.From,
+	}
+
+	// insert into database
+	b.DB.NewRecord(newNick)
+	if err := b.DB.Create(&newNick); err != nil {
+		return false, err
+	}
+
+	return true, nil
 }

--- a/bitbot/nickShuffle.go
+++ b/bitbot/nickShuffle.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/whyrusleeping/hellabot"
 )
 
@@ -38,7 +39,7 @@ func nickShuffleDispatcher(irc *hbot.Bot, m *hbot.Message) (string, error) {
 	// split message, error out if too short
 	splitMsg := strings.Split(m.Content, " ")
 	if len(splitMsg) < 2 {
-		return "", fmt.Errorf("Not enough arguments. See !help nickShuffle")
+		return "", errors.New("Not enough arguments. See !help nickShuffle")
 	}
 
 	switch splitMsg[1] {
@@ -49,10 +50,10 @@ func nickShuffleDispatcher(irc *hbot.Bot, m *hbot.Message) (string, error) {
 	case "drop":
 		return dropNickFromDB(m)
 	default:
-		return "", fmt.Errorf("Invalid argument. See !help nickShuffle")
+		return "", errors.New("Invalid argument. See !help nickShuffle")
 	}
 
-	return "", fmt.Errorf("Switch statement failed somehow")
+	return "", errors.New("Switch statement failed somehow")
 }
 
 func addNickToDB(m *hbot.Message) (string, error) {
@@ -60,7 +61,7 @@ func addNickToDB(m *hbot.Message) (string, error) {
 	splitMsg := strings.Split(m.Content, " ")
 
 	if len(splitMsg) < 3 {
-		return "", fmt.Errorf("Not enough arguments. See !help nickShuffle")
+		return "", errors.New("Not enough arguments. See !help nickShuffle")
 	}
 
 	// grab nick, error out if invalid
@@ -71,6 +72,7 @@ func addNickToDB(m *hbot.Message) (string, error) {
 
 	// insert into database
 	b.DB.NewRecord(newNick)
+
 	if res := b.DB.Create(&newNick); res.Error != nil {
 		return "", res.Error
 	}

--- a/bitbot/nickShuffle.go
+++ b/bitbot/nickShuffle.go
@@ -98,6 +98,10 @@ func getRandomNick() (string, error) {
 		return "", res.Error
 	}
 
+	if len(nicks) < 1 {
+		return "", errors.New("No nicks in database")
+	}
+
 	// embrace the nest
 	return nicks[b.Random.Intn(len(nicks))].Nick, nil
 }

--- a/bitbot/nickShuffle.go
+++ b/bitbot/nickShuffle.go
@@ -2,17 +2,9 @@ package bitbot
 
 import (
 	"fmt"
-	"regexp"
-	"strconv"
 	"strings"
-	"time"
 
 	"github.com/whyrusleeping/hellabot"
-)
-
-var (
-	location   *time.Location
-	timeFormat string
 )
 
 // ReminderEvent : The Gorm struct that represents an event in the DB.
@@ -24,28 +16,51 @@ type NickList struct {
 
 var NickShuffleTrigger = NamedTrigger{ //nolint:gochecknoglobals,golint
 	ID:   "nickShuffle",
-	Help: "Add a nick to my shuffle. Usage: !nick add <nick>",
+	Help: "Add a nick to my shuffle. Usage: !nick add|drop|shuffle [nick]",
 	Init: func() error {
 		return b.DB.AutoMigrate(&NickList{}).Error
 	},
 	Condition: func(irc *hbot.Bot, m *hbot.Message) bool {
-		return m.Command == "PRIVMSG" && strings.HasPrefix(m.Trailing, "!nick add <nickname>")
+		return m.Command == "PRIVMSG" && strings.HasPrefix(m.Trailing, "!nick")
 	},
 	Action: func(irc *hbot.Bot, m *hbot.Message) bool {
-		ok, err := addNickToDB(m)
-		if !ok {
-			irc.Reply("Looks like something went wrong.")
-			irc.Reply(err.Error())
+		msg, err := nickShuffleDispatcher(irc, m)
+		if err != nil {
+			irc.Reply(m, err.Error())
+			return true
 		}
+		irc.Reply(m, msg)
 		return true
 	},
 }
 
-func addNickToDB(m *hbot.Message) (bool, error) {
+func nickShuffleDispatcher(irc *hbot.Bot, m *hbot.Message) (string, error) {
 	// split message, error out if too short
 	splitMsg := strings.Split(m.Content, " ")
+	if len(splitMsg) < 2 {
+		return "", fmt.Errorf("Not enough arguments. See !help nickShuffle")
+	}
+
+	switch splitMsg[1] {
+	case "add":
+		return addNickToDB(m)
+	case "shuffle":
+		return shuffleNickFromDB(irc, m)
+	case "drop":
+		return dropNickFromDB(m)
+	default:
+		return "", fmt.Errorf("Invalid argument. See !help nickShuffle")
+	}
+
+	return "", fmt.Errorf("Switch statement failed somehow")
+}
+
+func addNickToDB(m *hbot.Message) (string, error) {
+	// split message, error out if too short
+	splitMsg := strings.Split(m.Content, " ")
+
 	if len(splitMsg) < 3 {
-		return false, fmt.Errorf("Not enough arguments. See !help nickShuffle")
+		return "", fmt.Errorf("Not enough arguments. See !help nickShuffle")
 	}
 
 	// grab nick, error out if invalid
@@ -56,9 +71,39 @@ func addNickToDB(m *hbot.Message) (bool, error) {
 
 	// insert into database
 	b.DB.NewRecord(newNick)
-	if err := b.DB.Create(&newNick); err != nil {
-		return false, err
+	if res := b.DB.Create(&newNick); res.Error != nil {
+		return "", res.Error
+	} else {
+		fmt.Println(res.Value)
 	}
 
-	return true, nil
+	return fmt.Sprintf("%s added %s to my rotation", newNick.From, newNick.Nick), nil
+}
+
+func shuffleNickFromDB(irc *hbot.Bot, m *hbot.Message) (string, error) {
+
+	nick, err := getRandomNick()
+	if err != nil {
+		return "", nil
+	}
+
+	irc.SetNick(nick)
+	return "honk", nil
+}
+
+func getRandomNick() (string, error) {
+	var nicks []NickList
+
+	res := b.DB.Find(&nicks)
+
+	if res.Error != nil {
+		return "", res.Error
+	}
+
+	// embrace the nest
+	return nicks[b.Random.Intn(len(nicks))].Nick, nil
+}
+
+func dropNickFromDB(m *hbot.Message) (string, error) {
+	return "can't delete yet, boss", nil
 }

--- a/bitbot/nickShuffle.go
+++ b/bitbot/nickShuffle.go
@@ -1,0 +1,60 @@
+package bitbot
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/whyrusleeping/hellabot"
+)
+
+var (
+	location   *time.Location
+	timeFormat string
+)
+
+// ReminderEvent : The Gorm struct that represents an event in the DB.
+type NickList struct {
+	ID   int    `gorm:"unique;AUTO_INCREMENT;PRIMARY_KEY"`
+	Nick string `gorm:"unique"`
+}
+
+var NickShuffleTrigger = NamedTrigger{ //nolint:gochecknoglobals,golint
+	ID:   "nickShuffle",
+	Help: "Add a nick to my shuffle. Usage: !nick add|drop <nick>",
+	Init: func() error {
+		return b.DB.AutoMigrate(&NickList{}).Error
+	},
+	Condition: func(irc *hbot.Bot, m *hbot.Message) bool {
+		return m.Command == "PRIVMSG" && strings.HasPrefix(m.Trailing, "!remind")
+	},
+	Action: func(irc *hbot.Bot, m *hbot.Message) bool {
+		timeFormat = "2006-01-02 15:04"
+
+		splitMSG := strings.Split(m.Content, " ")
+		if len(splitMSG) < 2 {
+			irc.Reply(m, "Not enough arguments provided")
+			return true
+		}
+
+		switch splitMSG[1] {
+		case "time":
+			irc.Reply(m, getTime())
+		case "add":
+			irc.Reply(m, addEvent(m, irc))
+		case "remove":
+			irc.Reply(m, removeEvent(m))
+		case "list":
+			irc.Reply(m, listEvents(m, irc))
+		case "join":
+			irc.Reply(m, joinEvent(m))
+		case "part":
+			irc.Reply(m, partEvent(m))
+		default:
+			irc.Reply(m, "Wrong argument")
+		}
+		return true
+	},
+}

--- a/bitbot/nickShuffle.go
+++ b/bitbot/nickShuffle.go
@@ -107,5 +107,22 @@ func getRandomNick() (string, error) {
 }
 
 func dropNickFromDB(m *hbot.Message) (string, error) {
-	return "can't delete yet, boss", nil
+	// split message, error out if too short
+	splitMsg := strings.Split(m.Content, " ")
+
+	if len(splitMsg) < 3 {
+		return "", errors.New("Not enough arguments. See !help nickShuffle")
+	}
+
+	// grab nick, error out if invalid
+	nick := NickList{
+		Nick: splitMsg[2],
+	}
+	// insert into database
+	res := b.DB.Delete(&nick)
+	if res.Error != nil {
+		return "", res.Error
+	}
+
+	return fmt.Sprintf("%s removed %s from my rotation", m.From, nick.Nick), nil
 }

--- a/bitbot/nickShuffle.go
+++ b/bitbot/nickShuffle.go
@@ -52,8 +52,6 @@ func nickShuffleDispatcher(irc *hbot.Bot, m *hbot.Message) (string, error) {
 	default:
 		return "", errors.New("Invalid argument. See !help nickShuffle")
 	}
-
-	return "", errors.New("Switch statement failed somehow")
 }
 
 func addNickToDB(m *hbot.Message) (string, error) {

--- a/bitbot/nickShuffle.go
+++ b/bitbot/nickShuffle.go
@@ -82,7 +82,7 @@ func shuffleNickFromDB(irc *hbot.Bot) (string, error) {
 
 	nick, err := getRandomNick()
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 
 	irc.SetNick(nick)

--- a/bitbot/nickShuffle.go
+++ b/bitbot/nickShuffle.go
@@ -7,7 +7,7 @@ import (
 	"github.com/whyrusleeping/hellabot"
 )
 
-// ReminderEvent : The Gorm struct that represents an event in the DB.
+// NickList : The Gorm struct that represents a nickname row in the database
 type NickList struct {
 	ID   int    `gorm:"unique;AUTO_INCREMENT;PRIMARY_KEY"` // Primary Key
 	Nick string `gorm:"unique"`                            // Nickname to use
@@ -45,7 +45,7 @@ func nickShuffleDispatcher(irc *hbot.Bot, m *hbot.Message) (string, error) {
 	case "add":
 		return addNickToDB(m)
 	case "shuffle":
-		return shuffleNickFromDB(irc, m)
+		return shuffleNickFromDB(irc)
 	case "drop":
 		return dropNickFromDB(m)
 	default:
@@ -73,14 +73,12 @@ func addNickToDB(m *hbot.Message) (string, error) {
 	b.DB.NewRecord(newNick)
 	if res := b.DB.Create(&newNick); res.Error != nil {
 		return "", res.Error
-	} else {
-		fmt.Println(res.Value)
 	}
 
 	return fmt.Sprintf("%s added %s to my rotation", newNick.From, newNick.Nick), nil
 }
 
-func shuffleNickFromDB(irc *hbot.Bot, m *hbot.Message) (string, error) {
+func shuffleNickFromDB(irc *hbot.Bot) (string, error) {
 
 	nick, err := getRandomNick()
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,6 +79,7 @@ var pluginMap = map[string]bitbot.NamedTrigger{
 	"reminder":       bitbot.ReminderTrigger,
 	"lennyface":      bitbot.LennyTrigger,
 	"DamnWeebs":      bitbot.WeebTrigger,
+	"nickShuffle":    bitbot.NickShuffleTrigger,
 }
 
 // rootCmd represents the base command when called without any subcommands

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/justinian/dice v0.0.0-20170728002755-6a18b51d929c
 	github.com/leanovate/gopter v0.2.4
 	github.com/mb-14/gomarkov v0.0.0-20190125094512-044dd0dcb5e7
+	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.2.1
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,7 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=


### PR DESCRIPTION
This PR adds a trigger that allows users to submit new nicknames to the bot's database that can use used in a "shuffle." The shuffle can be requested manually or used as part nickname collision detection. Support for ACLs and nick dropping has not been included yet.